### PR TITLE
Startup crash fix

### DIFF
--- a/lib/libeldenring/Cargo.toml
+++ b/lib/libeldenring/Cargo.toml
@@ -13,7 +13,7 @@ parking_lot = "0.12.0"
 tracing = "0.1.37"
 
 [dependencies.windows]
-version = "0.34.0"
+version = "0.51.0"
 features = [
   "Win32_Foundation",
   "Win32_Storage_FileSystem",

--- a/lib/libeldenring/src/pointers.rs
+++ b/lib/libeldenring/src/pointers.rs
@@ -1,9 +1,7 @@
 #![allow(clippy::new_without_default)]
 
 use std::fmt::Display;
-use std::ptr::null_mut;
 
-use windows::core::PCSTR;
 use windows::Win32::System::LibraryLoader::GetModuleHandleA;
 
 use crate::memedit::*;
@@ -155,7 +153,7 @@ impl Display for CharacterStats {
 
 impl Pointers {
     pub fn new() -> Self {
-        let base_module_address = unsafe { GetModuleHandleA(PCSTR(null_mut())) }.0 as usize;
+        let base_module_address = unsafe { GetModuleHandleA(None).unwrap() }.0 as usize;
         let base_addresses = BaseAddresses::from(*crate::version::VERSION)
             .with_module_base_addr(base_module_address);
 

--- a/practice-tool/src/lib.rs
+++ b/practice-tool/src/lib.rs
@@ -485,10 +485,11 @@ pub unsafe extern "stdcall" fn DllMain(
     _: *mut ::std::ffi::c_void,
 ) {
     if reason == DLL_PROCESS_ATTACH {
-        trace!("DllMain()");
         thread::spawn(move || {
+            let practice_tool = PracticeTool::new();
+
             if let Err(e) = Hudhook::builder()
-                .with(PracticeTool::new().into_hook::<ImguiDx12Hooks>())
+                .with(practice_tool.into_hook::<ImguiDx12Hooks>())
                 .with_hmodule(hmodule)
                 .build()
                 .apply()

--- a/practice-tool/src/main.rs
+++ b/practice-tool/src/main.rs
@@ -160,9 +160,9 @@ fn perform_injection() -> Result<(), String> {
     let syringe = Syringe::for_process(process);
     syringe.inject(dll_path).map_err(|e| {
         format!(
-            "Could not hook the practice tool: {e}.\n\nPlease make sure you have no antiviruses \
-             running, EAC is properly bypassed, and you are running an unmodded and legitimate \
-             version of the game."
+            "Could not hook the practice tool: {e}.\n\nPlease make sure you have
+            no antiviruses running, EAC is properly bypassed, and you are
+            running an unmodded and legitimate version of the game."
         )
     })?;
 

--- a/xtask/src/codegen/aob_scans.rs
+++ b/xtask/src/codegen/aob_scans.rs
@@ -446,10 +446,10 @@ fn codegen_version_enum(ver: &[VersionData]) -> String {
 
 fn patches_paths() -> impl Iterator<Item = PathBuf> {
     let base_path = PathBuf::from(
-        env::var("ERPT_PATCHES_PATH").unwrap_or_else(|_| panic!("{}", dedent(r#"
+        env::var("ERPT_PATCHES_PATH").unwrap_or_else(|_| panic!("{}", dedent(r"
             ERPT_PATCHES_PATH environment variable undefined.
             Check the documentation: https://github.com/veeenu/eldenring-practice-tool/README.md#building
-        "#))),
+        "))),
     );
     base_path
         .read_dir()


### PR DESCRIPTION
This fixes a long term crash when starting the tool too early. The culprit was found to be a bad memory access.
See also veeenu/darksoulsiii-practice-tool#35