### PR TITLE
Added a missing weapon, with categorie names fixed

### DIFF
--- a/practice-tool/src/widgets/item_ids.json
+++ b/practice-tool/src/widgets/item_ids.json
@@ -4433,7 +4433,7 @@
     ]
   },
   {
-    "node": "Talismans",
+    "node": "Accessories",
     "children": [
       {
         "node": "Crimson Amber Medallion",
@@ -8859,7 +8859,12 @@
       {
         "node": "Gravel Stone",
         "value": 1073762679
-      },
+      }
+    ]
+  },
+  {
+    "node": "Spirit Ashes",
+    "children": [
       {
         "node": "Black Knife Tiche",
         "value": 1073941824
@@ -11679,7 +11684,7 @@
     ]
   },
   {
-    "node": "Magic",
+    "node": "Spells",
     "children": [
       {
         "node": "Glintstone Pebble",
@@ -13178,6 +13183,10 @@
       {
         "node": "Beast Claw",
         "value": 68500000
+      },
+      {
+        "node": "Red Bear's Claw",
+        "value": 68510000
       }
     ]
   },
@@ -13767,7 +13776,7 @@
     ]
   },
   {
-    "node": "DLC Accessory",
+    "node": "DLC Accessories",
     "children": [
       {
         "node": "Perfumer's Talisman",
@@ -14309,174 +14318,6 @@
       {
         "node": "Charming Branch",
         "value": 1075745174
-      },
-      {
-        "node": "Miriam's Vanishing",
-        "value": 1075746124
-      },
-      {
-        "node": "Glintblade Trio",
-        "value": 1075746134
-      },
-      {
-        "node": "Rellana's Twin Moons",
-        "value": 1075746144
-      },
-      {
-        "node": "Glintstone Nail",
-        "value": 1075746324
-      },
-      {
-        "node": "Glintstone Nails",
-        "value": 1075746334
-      },
-      {
-        "node": "Blades of Stone",
-        "value": 1075746524
-      },
-      {
-        "node": "Gravitational Missile",
-        "value": 1075746534
-      },
-      {
-        "node": "Mantle of Thorns",
-        "value": 1075746724
-      },
-      {
-        "node": "Impenetrable Thorns",
-        "value": 1075746734
-      },
-      {
-        "node": "Rings of Spectral Light",
-        "value": 1075746824
-      },
-      {
-        "node": "Vortex of Putrescence",
-        "value": 1075748024
-      },
-      {
-        "node": "Mass of Putrescence",
-        "value": 1075748034
-      },
-      {
-        "node": "Furious Blade of Ansbach",
-        "value": 1075748124
-      },
-      {
-        "node": "Heal from Afar",
-        "value": 1075748224
-      },
-      {
-        "node": "Aspects of the Crucible: Thorns",
-        "value": 1075748474
-      },
-      {
-        "node": "Aspects of the Crucible: Bloom",
-        "value": 1075748484
-      },
-      {
-        "node": "Minor Erdtree",
-        "value": 1075748494
-      },
-      {
-        "node": "Land of Shadow",
-        "value": 1075748504
-      },
-      {
-        "node": "Wrath from Afar",
-        "value": 1075748514
-      },
-      {
-        "node": "Light of Miquella",
-        "value": 1075748524
-      },
-      {
-        "node": "Multilayered Ring of Light",
-        "value": 1075748534
-      },
-      {
-        "node": "Roar of Rugalea",
-        "value": 1075748624
-      },
-      {
-        "node": "Knight's Lightning Spear",
-        "value": 1075748724
-      },
-      {
-        "node": "Dragonbolt of Florissax",
-        "value": 1075748734
-      },
-      {
-        "node": "Electrocharge",
-        "value": 1075748744
-      },
-      {
-        "node": "Bayle's Tyranny",
-        "value": 1075748824
-      },
-      {
-        "node": "Bayle's Flame Lightning",
-        "value": 1075748834
-      },
-      {
-        "node": "Ghostflame Breath",
-        "value": 1075748844
-      },
-      {
-        "node": "Rotten Butterflies",
-        "value": 1075749024
-      },
-      {
-        "node": "Pest-Thread Spears",
-        "value": 1075749034
-      },
-      {
-        "node": "Midra's Flame of Frenzy",
-        "value": 1075749124
-      },
-      {
-        "node": "Fleeting Microcosm",
-        "value": 1075749234
-      },
-      {
-        "node": "Cherishing Fingers",
-        "value": 1075749244
-      },
-      {
-        "node": "Watchful Spirit",
-        "value": 1075749424
-      },
-      {
-        "node": "Golden Arcs",
-        "value": 1075749524
-      },
-      {
-        "node": "Giant Golden Arc",
-        "value": 1075749534
-      },
-      {
-        "node": "Spira",
-        "value": 1075749544
-      },
-      {
-        "node": "Divine Beast Tornado",
-        "value": 1075749554
-      },
-      {
-        "node": "Divine Bird Feathers",
-        "value": 1075749564
-      },
-      {
-        "node": "Fire Serpent",
-        "value": 1075749624
-      },
-      {
-        "node": "Rain of Fire",
-        "value": 1075749634
-      },
-      {
-        "node": "Messmer's Orb",
-        "value": 1075749644
       },
       {
         "node": "Miquella's Great Rune",
@@ -15085,7 +14926,12 @@
       {
         "node": "Furnace Visage",
         "value": 1075761859
-      },
+      }
+    ]
+  },
+  {
+    "node": "DLC Spirit Ashes",
+    "children": [
       {
         "node": "Curseblade Meera",
         "value": 1075941824
@@ -15165,6 +15011,179 @@
       {
         "node": "Jolán and Anna",
         "value": 1075961824
+      }
+    ]
+  },
+  {
+    "node": "DLC Spells",
+    "children": [
+      {
+        "node": "Miriam's Vanishing",
+        "value": 1075746124
+      },
+      {
+        "node": "Glintblade Trio",
+        "value": 1075746134
+      },
+      {
+        "node": "Rellana's Twin Moons",
+        "value": 1075746144
+      },
+      {
+        "node": "Glintstone Nail",
+        "value": 1075746324
+      },
+      {
+        "node": "Glintstone Nails",
+        "value": 1075746334
+      },
+      {
+        "node": "Blades of Stone",
+        "value": 1075746524
+      },
+      {
+        "node": "Gravitational Missile",
+        "value": 1075746534
+      },
+      {
+        "node": "Mantle of Thorns",
+        "value": 1075746724
+      },
+      {
+        "node": "Impenetrable Thorns",
+        "value": 1075746734
+      },
+      {
+        "node": "Rings of Spectral Light",
+        "value": 1075746824
+      },
+      {
+        "node": "Vortex of Putrescence",
+        "value": 1075748024
+      },
+      {
+        "node": "Mass of Putrescence",
+        "value": 1075748034
+      },
+      {
+        "node": "Furious Blade of Ansbach",
+        "value": 1075748124
+      },
+      {
+        "node": "Heal from Afar",
+        "value": 1075748224
+      },
+      {
+        "node": "Aspects of the Crucible: Thorns",
+        "value": 1075748474
+      },
+      {
+        "node": "Aspects of the Crucible: Bloom",
+        "value": 1075748484
+      },
+      {
+        "node": "Minor Erdtree",
+        "value": 1075748494
+      },
+      {
+        "node": "Land of Shadow",
+        "value": 1075748504
+      },
+      {
+        "node": "Wrath from Afar",
+        "value": 1075748514
+      },
+      {
+        "node": "Light of Miquella",
+        "value": 1075748524
+      },
+      {
+        "node": "Multilayered Ring of Light",
+        "value": 1075748534
+      },
+      {
+        "node": "Roar of Rugalea",
+        "value": 1075748624
+      },
+      {
+        "node": "Knight's Lightning Spear",
+        "value": 1075748724
+      },
+      {
+        "node": "Dragonbolt of Florissax",
+        "value": 1075748734
+      },
+      {
+        "node": "Electrocharge",
+        "value": 1075748744
+      },
+      {
+        "node": "Bayle's Tyranny",
+        "value": 1075748824
+      },
+      {
+        "node": "Bayle's Flame Lightning",
+        "value": 1075748834
+      },
+      {
+        "node": "Ghostflame Breath",
+        "value": 1075748844
+      },
+      {
+        "node": "Rotten Butterflies",
+        "value": 1075749024
+      },
+      {
+        "node": "Pest-Thread Spears",
+        "value": 1075749034
+      },
+      {
+        "node": "Midra's Flame of Frenzy",
+        "value": 1075749124
+      },
+      {
+        "node": "Fleeting Microcosm",
+        "value": 1075749234
+      },
+      {
+        "node": "Cherishing Fingers",
+        "value": 1075749244
+      },
+      {
+        "node": "Watchful Spirit",
+        "value": 1075749424
+      },
+      {
+        "node": "Golden Arcs",
+        "value": 1075749524
+      },
+      {
+        "node": "Giant Golden Arc",
+        "value": 1075749534
+      },
+      {
+        "node": "Spira",
+        "value": 1075749544
+      },
+      {
+        "node": "Divine Beast Tornado",
+        "value": 1075749554
+      },
+      {
+        "node": "Divine Bird Feathers",
+        "value": 1075749564
+      },
+      {
+        "node": "Fire Serpent",
+        "value": 1075749624
+      },
+      {
+        "node": "Rain of Fire",
+        "value": 1075749634
+      },
+      {
+        "node": "Messmer's Orb",
+        "value": 1075749644
       }
     ]
   },

--- a/xtask/src/codegen/item_ids.yml
+++ b/xtask/src/codegen/item_ids.yml
@@ -1116,7 +1116,7 @@
     "Mushroom Crown": 0x101eab90
     "Black Dumpling": 0x101ed2a0
     "Lazuli Robe": 0x101ef9b0
-"Talismans":
+"Accessories":
     "Crimson Amber Medallion": 0x200003e8
     "Crimson Amber Medallion +1": 0x200003e9
     "Crimson Amber Medallion +2": 0x200003ea
@@ -2223,6 +2223,7 @@
     "Volcanic Stone": 0x40005172
     "Formic Rock": 0x40005174
     "Gravel Stone": 0x40005177
+"Spirit Ashes":
     "Black Knife Tiche": 0x40030d40
     "Black Knife Tiche +1": 0x40030d41
     "Black Knife Tiche +2": 0x40030d42
@@ -2927,7 +2928,7 @@
     "Jarwight Puppet +8": 0x40040360
     "Jarwight Puppet +9": 0x40040361
     "Jarwight Puppet +10": 0x40040362
-"Magic":
+"Spells":
     "Glintstone Pebble": 0x40000fa0
     "Great Glintstone Shard": 0x40000fa1
     "Swift Glintstone Shard": 0x40000faa
@@ -3419,6 +3420,7 @@
     "Leda's Sword": 0x04061EF0
     "Rellana's Twin Blades": 0x04064600
     "Beast Claw": 0x04153A20
+    "Red Bear's Claw": 0x04156130
 "DLC Armor":
     "Dane's Hat": 0x102DC6C0
     "Dryleaf Robe": 0x102DC724
@@ -3565,7 +3567,7 @@
     "Crucible Hammer-Helm": 0x10510630
     "Greatjar": 0x10512D40
     "Imp Head (Lion)": 0x10515450
-"DLC Accessory":
+"DLC Accessories":
     "Perfumer's Talisman": 0x200008AC
     "Crimson Amber Medallion +3": 0x20001B58
     "Cerulean Amber Medallion +3": 0x20001B62
@@ -3701,48 +3703,6 @@
     "Glinting Nail": 0x401E9100
     "Sunwarmth Stone": 0x401E916E
     "Charming Branch": 0x401E9196
-    "Miriam's Vanishing": 0x401E954C
-    "Glintblade Trio": 0x401E9556
-    "Rellana's Twin Moons": 0x401E9560
-    "Glintstone Nail": 0x401E9614
-    "Glintstone Nails": 0x401E961E
-    "Blades of Stone": 0x401E96DC
-    "Gravitational Missile": 0x401E96E6
-    "Mantle of Thorns": 0x401E97A4
-    "Impenetrable Thorns": 0x401E97AE
-    "Rings of Spectral Light": 0x401E9808
-    "Vortex of Putrescence": 0x401E9CB8
-    "Mass of Putrescence": 0x401E9CC2
-    "Furious Blade of Ansbach": 0x401E9D1C
-    "Heal from Afar": 0x401E9D80
-    "Aspects of the Crucible: Thorns": 0x401E9E7A
-    "Aspects of the Crucible: Bloom": 0x401E9E84
-    "Minor Erdtree": 0x401E9E8E
-    "Land of Shadow": 0x401E9E98
-    "Wrath from Afar": 0x401E9EA2
-    "Light of Miquella": 0x401E9EAC
-    "Multilayered Ring of Light": 0x401E9EB6
-    "Roar of Rugalea": 0x401E9F10
-    "Knight's Lightning Spear": 0x401E9F74
-    "Dragonbolt of Florissax": 0x401E9F7E
-    "Electrocharge": 0x401E9F88
-    "Bayle's Tyranny": 0x401E9FD8
-    "Bayle's Flame Lightning": 0x401E9FE2
-    "Ghostflame Breath": 0x401E9FEC
-    "Rotten Butterflies": 0x401EA0A0
-    "Pest-Thread Spears": 0x401EA0AA
-    "Midra's Flame of Frenzy": 0x401EA104
-    "Fleeting Microcosm": 0x401EA172
-    "Cherishing Fingers": 0x401EA17C
-    "Watchful Spirit": 0x401EA230
-    "Golden Arcs": 0x401EA294
-    "Giant Golden Arc": 0x401EA29E
-    "Spira": 0x401EA2A8
-    "Divine Beast Tornado": 0x401EA2B2
-    "Divine Bird Feathers": 0x401EA2BC
-    "Fire Serpent": 0x401EA2F8
-    "Rain of Fire": 0x401EA302
-    "Messmer's Orb": 0x401EA30C
     "Miquella's Great Rune": 0x401EA3C0
     "Igon's Furled Finger": 0x401EA3C3
     "Well Depths Key": 0x401EA3C4
@@ -3895,6 +3855,7 @@
     "Nailstone": 0x401ED2C1
     "Sharp Gravel Stone": 0x401ED2C2
     "Furnace Visage": 0x401ED2C3
+"DLC Spirit Ashes":
     "Curseblade Meera": 0x402191C0
     "Bloodfiend Hexer's Ashes": 0x402195A8
     "Gravebird Ashes": 0x40219990
@@ -3915,6 +3876,49 @@
     "Fire Knight Queelign": 0x4021D810
     "Swordhand of Night Jolán": 0x4021DBF8
     "Jolán and Anna": 0x4021DFE0
+"DLC Spells":
+    "Miriam's Vanishing": 0x401E954C
+    "Glintblade Trio": 0x401E9556
+    "Rellana's Twin Moons": 0x401E9560
+    "Glintstone Nail": 0x401E9614
+    "Glintstone Nails": 0x401E961E
+    "Blades of Stone": 0x401E96DC
+    "Gravitational Missile": 0x401E96E6
+    "Mantle of Thorns": 0x401E97A4
+    "Impenetrable Thorns": 0x401E97AE
+    "Rings of Spectral Light": 0x401E9808
+    "Vortex of Putrescence": 0x401E9CB8
+    "Mass of Putrescence": 0x401E9CC2
+    "Furious Blade of Ansbach": 0x401E9D1C
+    "Heal from Afar": 0x401E9D80
+    "Aspects of the Crucible: Thorns": 0x401E9E7A
+    "Aspects of the Crucible: Bloom": 0x401E9E84
+    "Minor Erdtree": 0x401E9E8E
+    "Land of Shadow": 0x401E9E98
+    "Wrath from Afar": 0x401E9EA2
+    "Light of Miquella": 0x401E9EAC
+    "Multilayered Ring of Light": 0x401E9EB6
+    "Roar of Rugalea": 0x401E9F10
+    "Knight's Lightning Spear": 0x401E9F74
+    "Dragonbolt of Florissax": 0x401E9F7E
+    "Electrocharge": 0x401E9F88
+    "Bayle's Tyranny": 0x401E9FD8
+    "Bayle's Flame Lightning": 0x401E9FE2
+    "Ghostflame Breath": 0x401E9FEC
+    "Rotten Butterflies": 0x401EA0A0
+    "Pest-Thread Spears": 0x401EA0AA
+    "Midra's Flame of Frenzy": 0x401EA104
+    "Fleeting Microcosm": 0x401EA172
+    "Cherishing Fingers": 0x401EA17C
+    "Watchful Spirit": 0x401EA230
+    "Golden Arcs": 0x401EA294
+    "Giant Golden Arc": 0x401EA29E
+    "Spira": 0x401EA2A8
+    "Divine Beast Tornado": 0x401EA2B2
+    "Divine Bird Feathers": 0x401EA2BC
+    "Fire Serpent": 0x401EA2F8
+    "Rain of Fire": 0x401EA302
+    "Messmer's Orb": 0x401EA30C
 "DLC Ashes of War":
     "Ash of War: Dryleaf Whirlwind": 0x80030D40
     "Ash of War: Aspects of the Crucible: Wings": 0x80030DA4


### PR DESCRIPTION
* Added the missing `Red Bear's Claw`
* Changes to item category names
  * `Magic` -> `Spells`
  * `Talismans` -> `Accessories`
  * `DLC Accessory` -> `DLC Accessories`
  * Move `Spirits Ashes`, `DLC Spells` and `DLC Spirit Ashes` into individual catogories