### PR TITLE
Wait for game initialization before applying patches

### DIFF
--- a/lib/libeldenring/src/pointers.rs
+++ b/lib/libeldenring/src/pointers.rs
@@ -56,6 +56,7 @@ pub struct Pointers {
 
     pub quitout: PointerChain<u8>,
     pub cursor_show: Bitflag<u8>,
+    pub menu_timer: PointerChain<f32>,
 
     pub gravity: Bitflag<u8>,
     pub display_stable_pos: Bitflag<u8>,
@@ -393,6 +394,13 @@ impl Pointers {
 
             quitout: pointer_chain!(cs_menu_man_imp, 0x8, 0x5d),
             cursor_show: bitflag!(0b1; cs_menu_man_imp, 0xAC),
+            menu_timer: pointer_chain!(cs_menu_man_imp, match version {
+                V1_02_0 | V1_02_1 | V1_02_2 | V1_02_3 => 0x708 + 0x24,
+                V1_03_0 | V1_03_1 | V1_03_2 | V1_04_0 | V1_04_1 | V1_05_0 | V1_06_0 | V1_07_0
+                | V1_08_0 | V1_08_1 | V1_09_0 | V1_09_1 | V2_00_0 | V2_00_1 => 0x718 + 0x24,
+                V2_02_0 | V2_02_3 | V2_03_0 | V2_04_0 | V2_05_0 | V2_06_0 => 0x720 + 0x24,
+            }),
+
             gravity: bitflag!(0b1; world_chr_man, player_ins, 0x190, 0x68, 0x1d3),
             display_stable_pos: bitflag!(0b1; world_chr_man, player_ins,
                 match version {

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -1,6 +1,7 @@
 use std::fmt::Write;
 use std::sync::Mutex;
-use std::time::Instant;
+use std::thread;
+use std::time::{Duration, Instant};
 
 use const_format::formatcp;
 use hudhook::tracing::metadata::LevelFilter;
@@ -150,6 +151,16 @@ impl PracticeTool {
             hudhook::free_console().ok();
         }
 
+        let pointers = Pointers::new();
+        let poll_interval = Duration::from_millis(100);
+        loop {
+            if let Some(menu_timer) = pointers.menu_timer.read() {
+                if menu_timer > 0. {
+                    break;
+                }
+            }
+            thread::sleep(poll_interval);
+        }
         wait_option_thread(
             || unsafe {
                 let mut params = PARAMS.write();
@@ -170,7 +181,6 @@ impl PracticeTool {
         let update_available =
             if config.settings.disable_update_prompt { Update::UpToDate } else { Update::check() };
 
-        let pointers = Pointers::new();
         let version_label = {
             let (maj, min, patch) = version::get_version().into();
             format!("Game Ver {}.{:02}.{}", maj, min, patch)


### PR DESCRIPTION
This resolves possible game crash when practice tool is running too early and applies patches before game initialization is finished.

Idea from [samjviana](https://github.com/samjviana)'s suggetion in https://github.com/soarqin/EROverlay/issues/8

The menu info struct offset in csMenuManImp is scanned using aob "48 8D 8B ?? ?? ?? ?? F3 0F 10 4F 08", while ?? ?? ?? ?? indicates the offset.
But xtask aob_scan does not support for direct scan with relative mem read, so I hard-coded the offset in pointer_chain