### PR TITLE
Add player distance indicator

### DIFF
--- a/jdsd_er_practice_tool.toml
+++ b/jdsd_er_practice_tool.toml
@@ -67,6 +67,7 @@ indicators = [
   { indicator = "igt", enabled = true },
   { indicator = "position", enabled = false },
   { indicator = "position_change", enabled = false },
+  { indicator = "position_distance", enabled = false },
   { indicator = "animation", enabled = false },
   { indicator = "fps", enabled = false },
   { indicator = "framecount", enabled = false },

--- a/practice-tool/src/config.rs
+++ b/practice-tool/src/config.rs
@@ -62,6 +62,7 @@ pub(crate) enum IndicatorType {
     Igt,
     Position,
     PositionChange,
+    PositionDistance,
     GameVersion,
     ImguiDebug,
     Fps,
@@ -83,6 +84,7 @@ impl Indicator {
             Indicator { indicator: IndicatorType::Igt, enabled: true },
             Indicator { indicator: IndicatorType::Position, enabled: false },
             Indicator { indicator: IndicatorType::PositionChange, enabled: false },
+            Indicator { indicator: IndicatorType::PositionDistance, enabled: false },
             Indicator { indicator: IndicatorType::Animation, enabled: false },
             Indicator { indicator: IndicatorType::Fps, enabled: false },
             Indicator { indicator: IndicatorType::FrameCount, enabled: false },
@@ -108,6 +110,10 @@ impl TryFrom<IndicatorConfig> for Indicator {
             },
             "position_change" => Ok(Indicator {
                 indicator: IndicatorType::PositionChange,
+                enabled: indicator.enabled,
+            }),
+            "position_distance" => Ok(Indicator {
+                indicator: IndicatorType::PositionDistance,
                 enabled: indicator.enabled,
             }),
             "animation" => {

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -63,6 +63,9 @@ pub(crate) struct PracticeTool {
     position_prev: [f32; 3],
     position_change_buf: String,
 
+    position_dist_ref: [f32; 3],
+    position_dist_buf: String,
+
     igt_buf: String,
     fps_buf: String,
 
@@ -219,6 +222,8 @@ impl PracticeTool {
             position_prev: Default::default(),
             position_bufs: Default::default(),
             position_change_buf: Default::default(),
+            position_dist_ref: Default::default(),
+            position_dist_buf: Default::default(),
             igt_buf: Default::default(),
             fps_buf: Default::default(),
             framecount: 0,
@@ -334,6 +339,7 @@ impl PracticeTool {
                                 IndicatorType::GameVersion => "Game Version",
                                 IndicatorType::Position => "Player Position",
                                 IndicatorType::PositionChange => "Player Velocity",
+                                IndicatorType::PositionDistance => "Player Distance",
                                 IndicatorType::Animation => "Animation",
                                 IndicatorType::Igt => "IGT Timer",
                                 IndicatorType::Fps => "FPS",
@@ -361,6 +367,25 @@ impl PracticeTool {
 
                                 if ui.button("Reset") {
                                     self.framecount = 0;
+                                }
+                            }
+
+                            if let IndicatorType::PositionDistance = indicator.indicator {
+                                ui.same_line();
+
+                                let btn_xyz_label = "Start XYZ";
+                                let btn_xyz_width = ui.calc_text_size(btn_xyz_label)[0]
+                                    + style.frame_padding[0] * 2.0;
+
+                                ui.set_cursor_pos([
+                                    ui.content_region_max()[0] - btn_xyz_width,
+                                    ui.cursor_pos()[1],
+                                ]);
+
+                                if ui.button("Start XYZ") {
+                                    if let Some([x, y, z, _a1, _a2]) = self.pointers.global_position.read() {
+                                        self.position_dist_ref = [x, y, z];
+                                    }
                                 }
                             }
                         }
@@ -543,13 +568,37 @@ impl PracticeTool {
                                 self.position_change_buf.clear();
                                 write!(
                                     self.position_change_buf,
-                                    "[XYZ] {position_change_xyz:.6} | [XZ] \
-                                     {position_change_xz:.6} | [Y] {position_change_y:.6}"
+                                    "Velocity: [XYZ] {position_change_xyz:.3} | [XZ] \
+                                     {position_change_xz:.3} | [Y] {position_change_y:.3}"
                                 )
                                 .ok();
                                 ui.text(&self.position_change_buf);
 
                                 self.position_prev = [x, y, z];
+                            }
+                        },
+                        IndicatorType::PositionDistance => {
+                            if let Some([x, y, z, _a1, _a2]) = self.pointers.global_position.read()
+                            {
+                                let position_dist_xyz = ((x - self.position_dist_ref[0]).powf(2.0)
+                                    + (y - self.position_dist_ref[1]).powf(2.0)
+                                    + (z - self.position_dist_ref[2]).powf(2.0))
+                                .sqrt();
+
+                                let position_dist_xz = ((x - self.position_dist_ref[0]).powf(2.0)
+                                    + (z - self.position_dist_ref[2]).powf(2.0))
+                                .sqrt();
+
+                                let position_dist_y = y - self.position_dist_ref[1];
+
+                                self.position_dist_buf.clear();
+                                write!(
+                                    self.position_dist_buf,
+                                    "Distance: [XYZ] {position_dist_xyz:.4} | [XZ] \
+                                     {position_dist_xz:.4} | [Y] {position_dist_y:.4}"
+                                )
+                                .ok();
+                                ui.text(&self.position_dist_buf);
                             }
                         },
                         IndicatorType::Animation => {

--- a/practice-tool/src/practice_tool.rs
+++ b/practice-tool/src/practice_tool.rs
@@ -383,7 +383,9 @@ impl PracticeTool {
                                 ]);
 
                                 if ui.button("Start XYZ") {
-                                    if let Some([x, y, z, _a1, _a2]) = self.pointers.global_position.read() {
+                                    if let Some([x, y, z, _a1, _a2]) =
+                                        self.pointers.global_position.read()
+                                    {
                                         self.position_dist_ref = [x, y, z];
                                     }
                                 }


### PR DESCRIPTION
This adds a simple indicator to measure player distance to a set point. The start point can be set via the "Start XYZ" button in the indicator menu.

Just like the velocity indicator, it has XYZ, XZ and Y distance. To differentiate the indicators a bit better, a label has been added to the start of them and the number of decimal places have been adjusted to make more sense (3 for velocity, 4 for distance).